### PR TITLE
[WIP] Optimize DataFetchingSelectionSet.getImmediateFields() to avoid traversing descendants

### DIFF
--- a/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
+++ b/src/test/groovy/graphql/schema/DataFetchingFieldSelectionSetImplTest.groovy
@@ -348,6 +348,49 @@ class DataFetchingFieldSelectionSetImplTest extends Specification {
         fields.collect({ field -> field.qualifiedName }) == expectedFieldName
     }
 
+    def "immediate fields followed by fields are computed"() {
+
+        when:
+        def ei = ExecutionInput.newExecutionInput(relayQuery).build()
+        def er = relayGraphql.execute(ei)
+
+        then:
+        er.getErrors().isEmpty()
+
+        List<SelectedField> immediateFields = selectionSet.getImmediateFields();
+
+        List<SelectedField> fieldsGlob = selectionSet.getFields("**")
+        List<SelectedField> fields = selectionSet.getFields()
+
+        def expectedImmediateFieldName = [
+                "nodes",
+                "edges",
+                "totalCount"
+        ]
+
+        def expectedFieldName = [
+                "nodes",
+                "nodes/key",
+                "nodes/summary",
+                "nodes/status",
+                "nodes/status/name",
+                "nodes/stuff",
+                "nodes/stuff/name",
+                "edges",
+                "edges/cursor",
+                "edges/node",
+                "edges/node/description",
+                "edges/node/status",
+                "edges/node/status/name",
+                "totalCount"
+        ]
+
+        then:
+        immediateFields.collect({ field -> field.qualifiedName }) == expectedImmediateFieldName
+        fieldsGlob.collect({ field -> field.qualifiedName }) == expectedFieldName
+        fields.collect({ field -> field.qualifiedName }) == expectedFieldName
+    }
+
     def petSDL = '''
             type Query {
                 petUnion : PetUnion

--- a/src/test/java/benchmark/DFSelectionSetBenchmark.java
+++ b/src/test/java/benchmark/DFSelectionSetBenchmark.java
@@ -88,9 +88,39 @@ public class DFSelectionSetBenchmark {
         blackhole.consume(fields);
     }
 
+    @Benchmark
+    @Warmup(iterations = 2)
+    @Measurement(iterations = 5, time = 10)
+    @Threads(1)
+    @Fork(3)
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void benchMarkAvgTime_getImmediateFields(MyState myState, Blackhole blackhole) {
+        List<SelectedField> fields = getImmediateFields(myState);
+        blackhole.consume(fields);
+    }
+
+    @Benchmark
+    @Warmup(iterations = 2)
+    @Measurement(iterations = 5, time = 10)
+    @Threads(1)
+    @Fork(3)
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public void benchMarkThroughput_getImmediateFields(MyState myState, Blackhole blackhole) {
+        List<SelectedField> fields = getImmediateFields(myState);
+        blackhole.consume(fields);
+    }
+
+
     private List<SelectedField> getSelectedFields(MyState myState) {
         DataFetchingFieldSelectionSet dataFetchingFieldSelectionSet = DataFetchingFieldSelectionSetImpl.newCollector(myState.schema, myState.outputFieldType, () -> myState.normalisedField);
         return dataFetchingFieldSelectionSet.getFields("wontBeFound");
+    }
+
+    private List<SelectedField> getImmediateFields(MyState myState) {
+        DataFetchingFieldSelectionSet dataFetchingFieldSelectionSet = DataFetchingFieldSelectionSetImpl.newCollector(myState.schema, myState.outputFieldType, () -> myState.normalisedField);
+        return dataFetchingFieldSelectionSet.getImmediateFields();
     }
 
     public static void mainX(String[] args) throws InterruptedException {


### PR DESCRIPTION
Our project heavily relies on using DataFetchingSelectionSet to optimize calls to our downstream services (using selection on our APIs to avoid over-fetching fields). 

The optimization to only calculate ExecutableNormalizedField is working as expected, however if we use the DataFetchingSelectionSet.getImmediateFields it is building the entire tree even though it only returns the immediate fields.